### PR TITLE
test(components): se agregaron pruebas unitarias para el componente Card que abarcaran los cambios realizados durante la creación del componente Filtro

### DIFF
--- a/src/app/components/card/card.component.spec.ts
+++ b/src/app/components/card/card.component.spec.ts
@@ -111,4 +111,34 @@ describe('CardComponent', () => {
 
      expect(component.getGenre()).toBeNull();
   })
+
+  it('should return "Ciencia ficción y Fantasía" if the movie includes both genres but appers first the sci-fi id in the genre-ids array', () => {
+    const component = new CardComponent();
+    component.movie = { 
+      poster_path: 'ruta/poster5.png', 
+      title: 'Prueba5',
+      release_date: '', 
+      genre_ids: [878, 14], 
+      id: 501255,
+      overview: 'Esta es una prueba',
+      vote_average: 6.5
+     }
+
+     expect(component.getGenre()).toEqual('Ciencia ficción y Fantasía');
+  })
+
+  it('should return "Fantasía y Ciencia ficción" if the movie includes both genres but appers first the fantasy id  in the genre-ids array', () => {
+    const component = new CardComponent();
+    component.movie = { 
+      poster_path: 'ruta/poster6.png', 
+      title: 'Prueba6',
+      release_date: '', 
+      genre_ids: [14, 878], 
+      id: 601266,
+      overview: 'Esta es una prueba',
+      vote_average: 8.5
+     }
+
+     expect(component.getGenre()).toEqual('Fantasía y Ciencia ficción');
+  })
 });


### PR DESCRIPTION
Durante la creación del filtro por género se detectó que había algunas películas que pertenecen tanto al género de fantasía como al de ciencia ficción y esto no se mostraba en la card de las películas por lo que se añadió una validación a la función getGenre del componente Card. Estos cambios son los que se abarcan en las pruebas agregadas en este commit.